### PR TITLE
Fix parameter typo in cellChanged signal

### DIFF
--- a/include/MainWindow.hpp
+++ b/include/MainWindow.hpp
@@ -116,7 +116,7 @@ public:
   QLineEdit* destEdit() { return m_actions->destEdit(); }
 
 signals:
-  void cellChanged(int row, int colomn);
+  void cellChanged(int row, int column);
   void browseRequested();
 
   void destRequested();


### PR DESCRIPTION
## Summary
- rename `colomn` parameter to `column` in `MainWindow` signal

## Testing
- `cmake -S . -B build` *(fails: Could not find Qt6)*

------
https://chatgpt.com/codex/tasks/task_e_68406c28bf40832289e07916585dd943